### PR TITLE
fix/remove_special_characters

### DIFF
--- a/mail/header.go
+++ b/mail/header.go
@@ -119,7 +119,10 @@ func isAtext(r rune, dot bool) bool {
 	case '.':
 		return dot
 	// RFC 5322 3.2.3 specials
-	case '(', ')', '[', ']', ';', '@', '\\', ',':
+	// MW specific
+	// '[', ']' removed RFC 5322 3.2.3 special characters
+	// because it appears in atext
+	case '(', ')', ';', '@', '\\', ',':
 		return false
 	case '<', '>', '"', ':':
 		return false


### PR DESCRIPTION
fix: removed the "[, ]" brackets to parse email header where Message-ID: <[abc@xyz.com]>. 
According to RFC 5322 3.2.3 it is a special character and special characters do not appear in atext. But we've found some email examples, which contain a special character in the Message-ID header.